### PR TITLE
Fix script linking

### DIFF
--- a/src/Ctx.ts
+++ b/src/Ctx.ts
@@ -2,7 +2,7 @@ import type { O, RR } from '@that-hatter/scrapi-factory/fp';
 import type { Command, Data, Github, Interaction, dd } from './lib/modules';
 import type { BitNames } from './ygo';
 
-export type Ctx = {
+export type CtxWithoutData = {
   readonly bot: dd.Bot;
   readonly commands: Command.Collection;
   readonly componentInteractions: Interaction.ComponentCollection;
@@ -19,4 +19,6 @@ export type Ctx = {
   readonly picsChannel: O.Option<bigint>;
   readonly emojis: RR.ReadonlyRecord<string, string>;
   readonly gitRef: O.Option<string>;
-} & Data.Loaded;
+};
+
+export type Ctx = CtxWithoutData & Data.Loaded;

--- a/src/Ctx.ts
+++ b/src/Ctx.ts
@@ -7,7 +7,6 @@ export type CtxWithoutData = {
   readonly commands: Command.Collection;
   readonly componentInteractions: Interaction.ComponentCollection;
   readonly github: Github.Github['rest'];
-  readonly bitNames: BitNames.BitNames;
   readonly prefix: string;
   readonly dev: {
     readonly admin: string;
@@ -21,4 +20,7 @@ export type CtxWithoutData = {
   readonly gitRef: O.Option<string>;
 };
 
-export type Ctx = CtxWithoutData & Data.Loaded;
+export type Ctx = {
+  readonly bitNames: BitNames.BitNames;
+} & CtxWithoutData &
+  Data.Loaded;

--- a/src/lib/commands/general/script.ts
+++ b/src/lib/commands/general/script.ts
@@ -1,6 +1,6 @@
-import { pipe, RTE } from '@that-hatter/scrapi-factory/fp';
-import { Card } from '../../../ygo';
-import { Button, Command, Op, str } from '../../modules';
+import { pipe, R, RTE, TE } from '@that-hatter/scrapi-factory/fp';
+import { Babel, Card, Scripts } from '../../../ygo';
+import { Button, Command, Err, Op, str } from '../../modules';
 
 const showScriptButton = Button.row([
   {
@@ -9,6 +9,14 @@ const showScriptButton = Button.row([
     customId: 'showScript',
   },
 ]);
+
+const noScriptError = (c: Babel.Card) =>
+  Err.forUser(
+    'There is no script for ' +
+      str.bold(c.name) +
+      ' ' +
+      str.parenthesized(str.inlineCode(c.id.toString()))
+  );
 
 export const script: Command.Command = {
   name: 'script',
@@ -20,7 +28,8 @@ export const script: Command.Command = {
       Card.bestMatch(parameters.join(' ')),
       RTE.flatMap((c) =>
         pipe(
-          Card.scriptURL(c),
+          Scripts.getUrl(c.id),
+          R.map(TE.fromOption(() => noScriptError(c))),
           RTE.map(str.clamped('<', '>')),
           RTE.map(str.prepend(str.bold(c.name) + '\n'))
         )

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -22,7 +22,6 @@ export const URLS = {
   SCRAPI_BOOK: 'https://projectignis.github.io/scrapi-book',
   YUGIPEDIA_WIKI: 'https://yugipedia.com/wiki/',
   YUGIPEDIA_API: 'https://yugipedia.com/api.php?action=ask&query=',
-  CARDSCRIPTS: 'https://github.com/ProjectIgnis/CardScripts/',
   BABEL_CDB: 'https://github.com/ProjectIgnis/BabelCDB/',
   YGORESOURCES_DB: 'https://db.ygoresources.com/',
   YGORESOURCES_DIFFS: 'https://texts.ygoresources.com/',

--- a/src/lib/interactions/cardSelect.ts
+++ b/src/lib/interactions/cardSelect.ts
@@ -16,38 +16,21 @@ import { Ctx } from '../../Ctx';
 import { Babel, Card, KonamiIds, Pics } from '../../ygo';
 import { Data, dd, Err, Interaction, Menu, Op, str } from '../modules';
 
+//prettier-ignore
 const MALISS: RR.ReadonlyRecord<string, string> = {
   ['86993168']: 'Why is a raven like a writing desk?',
   ['69272449']: 'Oh dear! Oh dear! I shall be too late!',
-  ['96676583']:
-    "Oh, you can't help that, we're all mad here. I'm mad. You're mad.",
-  ['32061192']:
-    'Once upon a time there were three little sisters, ' +
-    'and their names were Elsie, Lacie, and Tillie',
-  ['68059897']:
-    "You may call it 'nonsense' if you like, but I've heard nonsense " +
-    'compared with which that would be as sensible as a dictionary!',
-  ['95454996']:
-    "Why, sometimes I've believed as many as " +
-    'six impossible things before breakfast',
+  ['96676583']: "Oh, you can't help that, we're all mad here. I'm mad. You're mad.",
+  ['32061192']: 'Once upon a time there were three little sisters, and their names were Elsie, Lacie, and Tillie',
+  ['68059897']: "You may call it 'nonsense' if you like, but I've heard nonsense compared with which that would be as sensible as a dictionary!",
+  ['95454996']: "Why, sometimes I've believed as many as six impossible things before breakfast",
   ['21848500']: 'Off with her head!',
   ['68337209']: 'Down, down, down. Would the fall never come to an end!',
-  ['94722358']:
-    "The Hatter's remark seemed to have no sort of meaning in it, " +
-    'and yet it was certainly English.',
-  ['20726052']:
-    'and this time it vanished quite slowly, ' +
-    'beginning with the end of the tail, and ending with the grin, ' +
-    'which remained some time after the rest of it had gone.',
-  ['57111661']:
-    'Imagine her surprise, when the White Rabbit read out, ' +
-    "at the top of his shrill little voice, the name 'Alice!'",
-  ['20938824']:
-    'Suppose we change the subject, ' +
-    "I'm getting tired of this. I vote the young lady tells us a story.",
-  ['93453053']:
-    'And certainly the glass was beginning to melt away, ' +
-    'just like a bright silvery mist.',
+  ['94722358']: "The Hatter's remark seemed to have no sort of meaning in it, and yet it was certainly English.",
+  ['20726052']: 'and this time it vanished quite slowly, beginning with the end of the tail, and ending with the grin, which remained some time after the rest of it had gone.',
+  ['57111661']: "Imagine her surprise, when the White Rabbit read out, at the top of his shrill little voice, the name 'Alice!'",
+  ['20938824']: "Suppose we change the subject, I'm getting tired of this. I vote the young lady tells us a story.",
+  ['93453053']: 'And certainly the glass was beginning to melt away, just like a bright silvery mist.',
 };
 
 const extraContent = (id: number) =>

--- a/src/yard/Yard.ts
+++ b/src/yard/Yard.ts
@@ -1,5 +1,5 @@
 import * as sf from '@that-hatter/scrapi-factory';
-import { pipe, TE } from '@that-hatter/scrapi-factory/fp';
+import { pipe, RTE, TE } from '@that-hatter/scrapi-factory/fp';
 import * as path from 'node:path';
 import { PATHS } from '../lib/constants';
 import type { Data } from '../lib/modules';
@@ -11,13 +11,14 @@ const YARD_OPTIONS: sf.YardOptions = {
   directory: path.join(PATHS.DATA, 'scrapiyard', 'api'),
 };
 
-const update: TE.TaskEither<string, sf.Yard> = pipe(
+const update = pipe(
   Github.pullOrClone(
     'scrapiyard',
     'https://github.com/ProjectIgnis/scrapiyard'
   ),
   TE.flatMap(() => sf.loadYard(YARD_OPTIONS)),
-  TE.mapError(utils.stringify)
+  TE.mapError(utils.stringify),
+  RTE.fromTaskEither
 );
 
 export const data: Data.Data<'yard'> = {
@@ -26,7 +27,8 @@ export const data: Data.Data<'yard'> = {
   update,
   init: pipe(
     sf.loadYard(YARD_OPTIONS),
-    TE.orElse(() => update)
+    RTE.fromTaskEither,
+    RTE.orElse(() => update)
   ),
   commitFilter: (repo, files) => {
     if (repo === 'scrapiyard')

--- a/src/ygo/Babel.ts
+++ b/src/ygo/Babel.ts
@@ -1,4 +1,4 @@
-import { O, pipe, RA, RNEA, RR, TE } from '@that-hatter/scrapi-factory/fp';
+import { O, pipe, RA, RNEA, RR, RTE, TE } from '@that-hatter/scrapi-factory/fp';
 import Database from 'better-sqlite3';
 import { ioEither } from 'fp-ts';
 import MiniSearch, { SearchResult } from 'minisearch';
@@ -261,10 +261,11 @@ const loadBabel: TE.TaskEither<string, Babel> = pipe(
   })
 );
 
-const update: TE.TaskEither<string, Babel> = pipe(
+const update = pipe(
   Github.pullOrClone('BabelCDB', 'https://github.com/ProjectIgnis/BabelCDB'),
   TE.flatMap(() => loadBabel),
-  TE.mapError(utils.stringify)
+  TE.mapError(utils.stringify),
+  RTE.fromTaskEither
 );
 
 export const data: Data.Data<'babel'> = {
@@ -273,7 +274,8 @@ export const data: Data.Data<'babel'> = {
   update,
   init: pipe(
     loadBabel,
-    TE.orElse(() => update)
+    RTE.fromTaskEither,
+    RTE.orElse(() => update)
   ),
   commitFilter: (repo, files) =>
     repo === 'BabelCDB' && files.some((f) => f.endsWith('.cdb')),

--- a/src/ygo/Banlists.ts
+++ b/src/ygo/Banlists.ts
@@ -5,6 +5,7 @@ import {
   RA,
   RNEA,
   RR,
+  RTE,
   TE,
 } from '@that-hatter/scrapi-factory/fp';
 import * as fs from 'node:fs/promises';
@@ -146,10 +147,11 @@ const loadBanlists = (): TE.TaskEither<string, Banlists> =>
     TE.flatMapOption(RNEA.fromReadonlyArray, () => 'No valid banlists found.')
   );
 
-const update: TE.TaskEither<string, Banlists> = pipe(
+const update = pipe(
   Github.pullOrClone('LFLists', GITHUB_URL),
   TE.flatMap(loadBanlists),
-  TE.mapError(utils.stringify)
+  TE.mapError(utils.stringify),
+  RTE.fromTaskEither
 );
 
 export const data: Data.Data<'banlists'> = {
@@ -157,8 +159,8 @@ export const data: Data.Data<'banlists'> = {
   description: 'Banlist data from LFLists.',
   update,
   init: pipe(
-    loadBanlists(),
-    TE.orElse(() => update)
+    loadBanlists,
+    RTE.orElse(() => update)
   ),
   commitFilter: (repo, files) =>
     repo === 'LFLists' && files.some((f) => f.endsWith('.lflist.conf')),

--- a/src/ygo/BetaIds.ts
+++ b/src/ygo/BetaIds.ts
@@ -1,4 +1,4 @@
-import { O, pipe, RA, RR, TE } from '@that-hatter/scrapi-factory/fp';
+import { O, pipe, RA, RR, RTE, TE } from '@that-hatter/scrapi-factory/fp';
 import fetch from 'node-fetch';
 import { Babel } from '.';
 import { Ctx } from '../Ctx';
@@ -23,7 +23,8 @@ const URL =
 
 const update = pipe(
   utils.taskify(() => fetch(URL).then((response) => response.json())),
-  TE.flatMapEither(Decoder.parse(decoder))
+  TE.flatMapEither(Decoder.parse(decoder)),
+  RTE.fromTaskEither
 );
 
 export const data: Data.Data<'betaIds'> = {

--- a/src/ygo/KonamiIds.ts
+++ b/src/ygo/KonamiIds.ts
@@ -1,4 +1,4 @@
-import { O, pipe, RA, RR, TE } from '@that-hatter/scrapi-factory/fp';
+import { O, pipe, RA, RR, RTE, TE } from '@that-hatter/scrapi-factory/fp';
 import fetch from 'node-fetch';
 import { Babel, Card, Pedia } from '.';
 import { Ctx } from '../Ctx';
@@ -22,7 +22,8 @@ const URL = `https://raw.githubusercontent.com/${OWNER}/${REPO}/${BRANCH}/${PATH
 
 const update = pipe(
   utils.taskify(() => fetch(URL).then((response) => response.json())),
-  TE.flatMapEither(Decoder.parse(decoder))
+  TE.flatMapEither(Decoder.parse(decoder)),
+  RTE.fromTaskEither
 );
 
 export const data: Data.Data<'konamiIds'> = {

--- a/src/ygo/Pics.ts
+++ b/src/ygo/Pics.ts
@@ -28,7 +28,8 @@ const decoder = Decoder.record(Decoder.string);
 
 const update = pipe(
   utils.taskify(() => fetch(URL).then((resp) => resp.json())),
-  TE.flatMapEither(Decoder.parse(decoder))
+  TE.flatMapEither(Decoder.parse(decoder)),
+  RTE.fromTaskEither
 );
 
 export const data: Data.Data<'pics'> = {

--- a/src/ygo/Scripts.ts
+++ b/src/ygo/Scripts.ts
@@ -1,4 +1,5 @@
 import { O, pipe, RA, RR, RTE } from '@that-hatter/scrapi-factory/fp';
+import { Ctx } from '../Ctx';
 import { Data } from '../lib/modules';
 import { listRepoFiles } from '../lib/modules/Github';
 
@@ -13,7 +14,7 @@ const update = pipe(
   RTE.map(
     RA.filterMap((f) => {
       if (!f.endsWith('.lua')) return O.none;
-      const [_, id] = f.split('/c');
+      const [_, id] = f.substring(0, f.length - 4).split('/c');
       if (!id) return O.none;
       return O.some([
         id,
@@ -33,3 +34,6 @@ export const data: Data.Data<'scripts'> = {
     repo === 'CardScripts' &&
     files.some((f) => f.endsWith('.lua') && f.includes('/c')),
 };
+
+export const getUrl = (id: number) => (ctx: Ctx) =>
+  O.fromNullable(ctx.scripts[id.toString()]);

--- a/src/ygo/Scripts.ts
+++ b/src/ygo/Scripts.ts
@@ -1,0 +1,35 @@
+import { O, pipe, RA, RR, RTE } from '@that-hatter/scrapi-factory/fp';
+import { Data } from '../lib/modules';
+import { listRepoFiles } from '../lib/modules/Github';
+
+const OWNER = 'ProjectIgnis';
+const REPO = 'CardScripts';
+const BRANCH = 'master';
+
+export type Scripts = RR.ReadonlyRecord<string, string>;
+
+const update = pipe(
+  listRepoFiles(OWNER, REPO, BRANCH),
+  RTE.map(
+    RA.filterMap((f) => {
+      if (!f.endsWith('.lua')) return O.none;
+      const [_, id] = f.split('/c');
+      if (!id) return O.none;
+      return O.some([
+        id,
+        `https://github.com/${OWNER}/${REPO}/blob/${BRANCH}/${f}`,
+      ] as const);
+    })
+  ),
+  RTE.map(RR.fromEntries)
+);
+
+export const data: Data.Data<'scripts'> = {
+  key: 'scripts',
+  description: 'Card script filepaths from the CardScript repo.',
+  update,
+  init: update,
+  commitFilter: (repo, files) =>
+    repo === 'CardScripts' &&
+    files.some((f) => f.endsWith('.lua') && f.includes('/c')),
+};

--- a/src/ygo/Shortcuts.ts
+++ b/src/ygo/Shortcuts.ts
@@ -1,4 +1,4 @@
-import { pipe, RA, RNEA, RR, TE } from '@that-hatter/scrapi-factory/fp';
+import { pipe, RA, RNEA, RR, RTE, TE } from '@that-hatter/scrapi-factory/fp';
 import fetch from 'node-fetch';
 import { Ctx } from '../Ctx';
 import type { Data } from '../lib/modules';
@@ -22,7 +22,8 @@ const URL =
 
 const update = pipe(
   utils.taskify(() => fetch(URL).then((response) => response.json())),
-  TE.flatMapEither(Decoder.parse(decoder))
+  TE.flatMapEither(Decoder.parse(decoder)),
+  RTE.fromTaskEither
 );
 
 export const data: Data.Data<'shortcuts'> = {

--- a/src/ygo/Systrings.ts
+++ b/src/ygo/Systrings.ts
@@ -61,7 +61,7 @@ const fetchAndParse = (repo: string) => {
   );
 };
 
-const update: TE.TaskEither<string, Systrings> = pipe(
+const update = pipe(
   fetchAndParse('DeltaBagooska'),
   TE.flatMap((delta) =>
     pipe(
@@ -74,7 +74,8 @@ const update: TE.TaskEither<string, Systrings> = pipe(
       ),
       TE.map(RA.concat(delta))
     )
-  )
+  ),
+  RTE.fromTaskEither
 );
 
 export const data: Data.Data<'systrings'> = {

--- a/src/ygo/index.ts
+++ b/src/ygo/index.ts
@@ -9,5 +9,6 @@ export * as Card from './Card';
 export * as Greenlight from './Greenlight';
 export * as KonamiIds from './KonamiIds';
 export * as Pics from './Pics';
+export * as Scripts from './Scripts';
 export * as Shortcuts from './Shortcuts';
 export * as Systrings from './Systrings';


### PR DESCRIPTION
A map of script urls is now generated on startup and auto-updated when the CardScripts repo is updated. This guarantees whether a script exists or not on lookup, rather than relying on heuristics to predict where the script is.

This fixes issues when linking to scripts of aliases (https://github.com/that-hatter/scrapi-searcher/issues/7) or linking to scripts that are in unexpected folders.